### PR TITLE
validate source is string

### DIFF
--- a/lib/logstash/filters/bytes.rb
+++ b/lib/logstash/filters/bytes.rb
@@ -64,7 +64,7 @@ class LogStash::Filters::Bytes < LogStash::Filters::Base
 
     source = event.get(@source)
 
-    if !source
+    if !source or !source.is_a? String
       @tag_on_failure.each{|tag| event.tag(tag)}
       return
     end


### PR DESCRIPTION
avoids continual crashing if array is provided